### PR TITLE
Fix OptionsFlowHandler config_entry setter error

### DIFF
--- a/custom_components/esy_sunhome/config_flow.py
+++ b/custom_components/esy_sunhome/config_flow.py
@@ -146,15 +146,11 @@ class ESYSunhomeFlowHandler(config_entries.ConfigFlow, domain="esy_sunhome"):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for ESY Sunhome."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
In newer versions of Home Assistant, the OptionsFlow base class has config_entry as a read-only property that's automatically set by the framework. Remove the custom __init__ that was trying to set it manually.