### PR TITLE
feat: app-matching watt power control + 3-phase telemetry fixes

### DIFF
--- a/custom_components/esy_sunhome/const.py
+++ b/custom_components/esy_sunhome/const.py
@@ -51,6 +51,11 @@ DEFAULT_TP_TYPE = 1
 DEFAULT_MCU_VERSION = 1049
 DEFAULT_MODE_CHANGE_METHOD = MODE_CHANGE_API
 
+# Rated AC power per phase (W). The ESY hardware is 5kW per phase, so a
+# single-phase unit is 5kW and a 3-phase unit is 15kW. Used as the 100% basis
+# for the battery charge/discharge % controls (watts = pct/100 * rated * phases).
+ESY_PER_PHASE_RATED_W = 5000
+
 # Core Power Sensors
 ATTR_SOC = "batterySoc"
 ATTR_GRID_POWER = "gridPower"

--- a/custom_components/esy_sunhome/coordinator.py
+++ b/custom_components/esy_sunhome/coordinator.py
@@ -20,6 +20,8 @@ from .const import (
     ESY_MQTT_PASSWORD,
     CONF_ENABLE_POLLING,
     DEFAULT_ENABLE_POLLING,
+    CONF_TP_TYPE,
+    DEFAULT_TP_TYPE,
 )
 from .esysunhome import ESYSunhomeAPI, MqttCredentials
 from .protocol import DynamicTelemetryParser, create_parser
@@ -76,7 +78,17 @@ class ESYSunhomeCoordinator(DataUpdateCoordinator):
         
         # Create parser with protocol
         self.parser = create_parser(protocol)
-        
+
+        # Phase type drives the 3-phase telemetry corrections in the parser and
+        # the rated-power basis (5kW per phase) used by the % power controls.
+        tp = config_entry.data.get(CONF_TP_TYPE, DEFAULT_TP_TYPE)
+        try:
+            tp = int(tp)
+        except (TypeError, ValueError):
+            tp = DEFAULT_TP_TYPE
+        self.phase_count = 3 if tp == 3 else 1
+        self.parser.set_tp_type(tp)
+
         # MQTT state
         self._mqtt_client: Optional[aiomqtt.Client] = None
         self._mqtt_task: Optional[asyncio.Task] = None

--- a/custom_components/esy_sunhome/number.py
+++ b/custom_components/esy_sunhome/number.py
@@ -1,16 +1,23 @@
 """ESY Sunhome number entities.
 
 Two groups:
-  * Power-control registers (charge/discharge current, export %, SOC limits) —
+  * Power-control registers (charge/discharge power, export %, SOC limits) —
     settable inverter registers, written over the MQTT register-write path,
     with addresses resolved per-model from the dynamic register map.
   * BEM SOC cutoffs (purchase/sale/use) — part of the server-side BEM schedule,
     written via the schedule REST API.
 
 Power-control entities are only created for registers present on the device's
-model. Units: this firmware exposes battery charge/discharge as *current* (A)
-and export limit as a *percentage* of rated power (the mobile app's watt values
-are converted to these by the backend).
+model.
+
+Charge/discharge are exposed as a *percentage* slider for a friendly UX, but —
+matching the ESY mobile app's normal user control — they are written as
+*watts* to the ``batteryChargePower`` / ``batteryDischargePower`` registers
+(the app sends raw watts to these; it is the installer pages that use the
+current/percent registers). The percentage is converted to watts against the
+unit's rated AC power (5kW per phase). The export limit is kept as a
+percentage (it maps to a grid feed-in cap, e.g. 5kW) and written to
+``antiBackflowPowerPercentage``.
 """
 from __future__ import annotations
 
@@ -25,12 +32,21 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import EsySunhomeEntity
+from .const import ESY_PER_PHASE_RATED_W
 from .protocol_api import FC_READ_HOLDING
 
 if TYPE_CHECKING:
     from .coordinator import ESYSunhomeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# How a control's slider value maps onto the register write:
+#   "raw"           — write the value directly (scaled by the register coeff).
+#   "watt_from_pct" — slider is a 0-100% of rated power; convert to watts
+#                     (pct/100 * rated_w) before writing. native_value reads the
+#                     watt register back and converts to a percentage.
+WRITE_RAW = "raw"
+WRITE_WATT_FROM_PCT = "watt_from_pct"
 
 
 # ---------------------------------------------------------------------------
@@ -49,19 +65,26 @@ class PowerControlDescriptor:
     max_value: float
     step: float
     icon: str
+    write_mode: str = WRITE_RAW
+    slider: bool = True
 
 
 # Candidate controls. Only those whose register exists on the device's model
 # (per the fetched register map) are actually created.
 CONTROLS: list[PowerControlDescriptor] = [
+    # Charge/discharge: % slider UI, written as watts to the app's normal-user
+    # power registers (batteryChargePower / batteryDischargePower).
     PowerControlDescriptor(
-        "batteryChargingCurrent", "battery_charge_current",
-        "Battery Charge Current", "A", 0, 100, 0.1, "mdi:battery-arrow-up",
+        "batteryChargePower", "battery_charge_power_pct",
+        "Battery Charge Power", "%", 0, 100, 1, "mdi:battery-arrow-up",
+        write_mode=WRITE_WATT_FROM_PCT,
     ),
     PowerControlDescriptor(
-        "batteryDischargeCurrent", "battery_discharge_current",
-        "Battery Discharge Current", "A", 0, 100, 0.1, "mdi:battery-arrow-down",
+        "batteryDischargePower", "battery_discharge_power_pct",
+        "Battery Discharge Power", "%", 0, 100, 1, "mdi:battery-arrow-down",
+        write_mode=WRITE_WATT_FROM_PCT,
     ),
+    # Export limit: kept as a percentage (grid feed-in cap, e.g. 5kW @ ~84%).
     PowerControlDescriptor(
         "antiBackflowPowerPercentage", "export_limit_percent",
         "Export Power Limit", "%", 0, 100, 1, "mdi:transmission-tower-export",
@@ -133,8 +156,6 @@ async def async_setup_entry(
 class ESYPowerControlNumber(EsySunhomeEntity, NumberEntity):
     """A settable power-control register exposed as a number entity."""
 
-    _attr_mode = NumberMode.BOX
-
     def __init__(self, coordinator, desc: PowerControlDescriptor, reg) -> None:
         # translation_key must be set before super().__init__ (used for unique_id)
         self._attr_translation_key = desc.translation_key
@@ -147,7 +168,14 @@ class ESYPowerControlNumber(EsySunhomeEntity, NumberEntity):
         self._attr_native_max_value = desc.max_value
         self._attr_native_step = desc.step
         self._attr_icon = desc.icon
+        self._attr_mode = NumberMode.SLIDER if desc.slider else NumberMode.BOX
         self._optimistic: Optional[float] = None
+
+    @property
+    def _rated_watts(self) -> float:
+        """Rated AC power (W) used as the 100% basis for % power controls."""
+        phases = getattr(self.coordinator, "phase_count", 1) or 1
+        return ESY_PER_PHASE_RATED_W * phases
 
     @property
     def native_value(self) -> Optional[float]:
@@ -156,12 +184,30 @@ class ESYPowerControlNumber(EsySunhomeEntity, NumberEntity):
             val = self.coordinator.data.get(self._desc.data_key)
         except Exception:  # noqa: BLE001 - coordinator data may be missing early
             val = None
-        return val if val is not None else self._optimistic
+        if val is None:
+            return self._optimistic
+        if self._desc.write_mode == WRITE_WATT_FROM_PCT:
+            # Telemetry reports watts; present it back as a percentage of rated.
+            rated = self._rated_watts or 1
+            pct = round(val / rated * 100)
+            return max(0, min(100, pct))
+        return val
 
     async def async_set_native_value(self, value: float) -> None:
-        """Write the value to the register (scaled by its coefficient)."""
+        """Write the value to the register.
+
+        For % power controls the slider value is converted to watts against the
+        rated power before scaling by the register coefficient; other controls
+        write their value directly (scaled by the coefficient).
+        """
         coef = self._reg.coefficient or 1
-        raw = int(round(value / coef))
+        if self._desc.write_mode == WRITE_WATT_FROM_PCT:
+            watts = round(value / 100 * self._rated_watts)
+            raw = int(round(watts / coef))
+            detail = f"{value:.0f}% -> {watts}W"
+        else:
+            raw = int(round(value / coef))
+            detail = f"{value}{self._desc.unit}"
         ok = await self.coordinator.write_register(self._reg.address, raw)
         if not ok:
             raise HomeAssistantError(
@@ -170,8 +216,8 @@ class ESYPowerControlNumber(EsySunhomeEntity, NumberEntity):
         self._optimistic = value
         self.async_write_ha_state()
         _LOGGER.info(
-            "Set %s = %s%s (register %d = %d)",
-            self._desc.name, value, self._desc.unit, self._reg.address, raw,
+            "Set %s = %s (register %d = %d)",
+            self._desc.name, detail, self._reg.address, raw,
         )
 
 

--- a/custom_components/esy_sunhome/protocol.py
+++ b/custom_components/esy_sunhome/protocol.py
@@ -144,8 +144,19 @@ class DynamicTelemetryParser:
         """Initialize with optional protocol definition."""
         self.protocol = protocol
         self.payload_parser = PayloadParser()
-        
-        # Key mappings for legacy compatibility
+
+        # Phase type: 1 = single-phase, 3 = three-phase. Set from the config
+        # entry by the coordinator; gates the 3-phase telemetry corrections in
+        # _compute_derived_values (ported from the solaniq_optimizer ESY adapter).
+        self.tp_type = 1
+
+        # Key mappings for legacy compatibility.
+        # Three-phase models expose grid/battery/load under different dataKeys
+        # (the totalPowerOf*InFlow / total*Power keys). Alias them onto the
+        # canonical keys the derive logic already consumes. NOTE:
+        # totalPowerOfGridInFlow is handled explicitly in _compute_derived_values
+        # because its sign convention differs (positive = import) from the
+        # ESY energyFlowGridPower figure, so it is intentionally NOT aliased here.
         self._legacy_key_map = {
             "battTotalSoc": "batterySoc",
             "ct1Power": "gridPower",
@@ -167,7 +178,19 @@ class DynamicTelemetryParser:
             "energyFlowBattPower": "energyFlowBatt",
             "energyFlowGridPower": "energyFlowGrid",
             "energyFlowLoadTotalPower": "energyFlowLoad",
+            # Three-phase aliases (battery in-flow + whole-site load totals).
+            "totalPowerOfBatteryInFlow": "energyFlowBatt",
+            "totalLoadActivePower": "loadRealTimePower",
+            "totalHouseholdLoadPower": "loadActivePower",
         }
+
+    def set_tp_type(self, tp_type: int) -> None:
+        """Set the site phase type (1 = single-phase, 3 = three-phase)."""
+        try:
+            self.tp_type = 3 if int(tp_type) == 3 else 1
+        except (TypeError, ValueError):
+            self.tp_type = 1
+        _LOGGER.info("Parser phase type set to %d-phase", self.tp_type)
 
     def set_protocol(self, protocol: ProtocolDefinition):
         """Set the protocol definition to use."""
@@ -327,63 +350,86 @@ class DynamicTelemetryParser:
             )
             total_grid_active = per_phase
 
-        # Choose the best source based on which has meaningful data
-        # Prefer ct1Power if it has significant magnitude, otherwise fall back
-        # NOTE: ct2Power when positive is AC-coupled PV, not grid!
-        if abs(ct1_power) > 10:
-            grid_power = ct1_power
-            grid_source = "ct1"
-        elif abs(grid_active_power) > 10:
-            grid_power = grid_active_power
-            grid_source = "active"
-        elif abs(total_grid_active) > 10:
-            grid_power = total_grid_active
-            grid_source = "3phase"
-        elif abs(energy_flow_grid) > 10:
-            grid_power = int(energy_flow_grid)
-            grid_source = "flow"
-        elif ct2_power < -10:
-            # Only use ct2Power for grid when it's NEGATIVE (not AC PV)
-            # Negative ct2Power could indicate grid import in some setups
-            grid_power = ct2_power
-            grid_source = "ct2"
+        # grid_power is computed in HA convention here: positive = import,
+        # negative = export. The raw CT/active registers use ESY's convention
+        # (negative = import) and are sign-flipped; the inverter in-flow figure
+        # used by 3-phase models (totalPowerOfGridInFlow) is already +import.
+        if self.tp_type == 3:
+            # ct1Power is a single-phase CT clamp (phase A only); on a 3-phase
+            # unit it under-reports whole-site grid, so exclude it. Prefer the
+            # inverter in-flow figure the ESY app shows (already +import), then
+            # the whole-site active total, then the ESY energy-flow grid figure.
+            flow_inflow = values.get("totalPowerOfGridInFlow")
+            if flow_inflow is not None and abs(flow_inflow) > 10:
+                grid_power = round(flow_inflow)          # already +import
+                grid_source = "flow3p"
+            elif abs(total_grid_active) > 10:
+                grid_power = -total_grid_active          # ESY -import -> +import
+                grid_source = "3phase"
+            elif abs(grid_active_power) > 10:
+                grid_power = -grid_active_power
+                grid_source = "active"
+            elif abs(energy_flow_grid) > 10:
+                grid_power = -int(energy_flow_grid)
+                grid_source = "flow"
+            else:
+                grid_power = -(total_grid_active or grid_active_power or int(energy_flow_grid))
+                grid_source = "fallback3p"
         else:
-            grid_power = ct1_power or grid_active_power or total_grid_active or int(energy_flow_grid)
-            grid_source = "fallback"
-        
-        # Negative = importing, Positive = exporting
-        # For Home Assistant: gridPower positive = import, negative = export
-        # So we need to FLIP the sign from ESY convention
-        result["gridPower"] = -grid_power  # Flip sign for HA convention
-        
-        # Apply sign convention for import/export
-        if grid_power < 0:
-            # ESY negative = importing from grid
-            result["gridImport"] = abs(grid_power)
+            # Single-phase: prefer ct1Power if it has significant magnitude,
+            # otherwise fall back. NOTE: ct2Power when positive is AC-coupled
+            # PV, not grid. Values are ESY raw (negative = import); flip below.
+            if abs(ct1_power) > 10:
+                esy_raw = ct1_power
+                grid_source = "ct1"
+            elif abs(grid_active_power) > 10:
+                esy_raw = grid_active_power
+                grid_source = "active"
+            elif abs(energy_flow_grid) > 10:
+                esy_raw = int(energy_flow_grid)
+                grid_source = "flow"
+            elif ct2_power < -10:
+                # Only use ct2Power for grid when it's NEGATIVE (not AC PV).
+                esy_raw = ct2_power
+                grid_source = "ct2"
+            else:
+                esy_raw = ct1_power or grid_active_power or int(energy_flow_grid)
+                grid_source = "fallback"
+            grid_power = -esy_raw  # Flip ESY convention -> HA (+import)
+
+        # HA convention: gridPower positive = import, negative = export.
+        result["gridPower"] = grid_power
+        if grid_power > 0:
+            result["gridImport"] = grid_power
             result["gridExport"] = 0
             result["gridLine"] = 1
-        elif grid_power > 0:
-            # ESY positive = exporting to grid
+        elif grid_power < 0:
             result["gridImport"] = 0
-            result["gridExport"] = grid_power
+            result["gridExport"] = -grid_power
             result["gridLine"] = 1
         else:
             result["gridImport"] = 0
             result["gridExport"] = 0
             result["gridLine"] = 0
-        
-        _LOGGER.debug("Grid: ct1=%d, ct2=%d, active=%d, flow=%d -> power=%d [%s] (import=%d, export=%d)",
-                     ct1_power, ct2_power, grid_active_power, int(energy_flow_grid),
+
+        _LOGGER.debug("Grid: ct1=%d, ct2=%d, active=%d, total3p=%d, flow=%d -> power=%d [%s] (import=%d, export=%d)",
+                     ct1_power, ct2_power, grid_active_power, total_grid_active, int(energy_flow_grid),
                      grid_power, grid_source, result["gridImport"], result["gridExport"])
         
         # === BATTERY POWER ===
         # Standard convention: Positive = Charging, Negative = Discharging
         
+        # Prefer the inverter's energy-flow battery figure (AC-side — what the
+        # ESY app shows on its battery tile, via energyFlowBattPower /
+        # totalPowerOfBatteryInFlow). The raw batteryPower register is DC-side
+        # and reads higher by the conversion loss (e.g. 2.6kW DC vs 2.2kW AC).
+        # Fall back to batteryPower when the flow figure is absent/zero.
         raw_batt_power = (
-            values.get("batteryPower") or
-            values.get("energyFlowBatt", 0) or 0
+            values.get("energyFlowBattPower") or
+            values.get("energyFlowBatt") or
+            values.get("batteryPower") or 0
         )
-        
+
         # Battery power from inverter is absolute - use batteryStatus to determine direction
         # batteryStatus codes from APK/Modbus register 28:
         # 0: Standby
@@ -461,15 +507,75 @@ class DynamicTelemetryParser:
                      raw_batt_power, battery_status, status_text, batt_power)
         
         # === LOAD POWER ===
+        # Prefer the inverter's energy-flow load figure (what the ESY app shows
+        # on its power-flow screen). On single-phase models this reads 0 and we
+        # fall through to the load registers (unchanged behaviour). Three-phase
+        # models expose the whole-site total under totalLoadActivePower /
+        # totalHouseholdLoadPower (aliased to the load* keys above).
         load_power = (
+            values.get("energyFlowLoadTotalPower") or
+            values.get("energyFlowLoad") or
             values.get("loadRealTimePower") or
             values.get("loadActivePower") or
-            values.get("loadPower") or
-            values.get("energyFlowLoad", 0) or 0
+            values.get("loadPower") or 0
         )
         result["loadPower"] = load_power
         result["loadLine"] = 1 if load_power > 10 else 0
-        
+
+        # === 3-PHASE FLOW NORMALISATION (match ESY app EnergyFlowOptimize.i) ===
+        # The 3-phase per-source registers are gross: pv + grid + battery
+        # overshoot the (accurate) load by a residual, so PV/grid/battery read a
+        # couple hundred watts high vs the app. The app forces conservation by
+        # subtracting the residual EQUALLY from each active flow (pv, grid,
+        # battery), leaving load fixed; we then dump any rounding leftover on the
+        # largest flow so pv + grid + battery == load exactly. Signed convention
+        # here: pv >= 0; grid +import/-export; batt +discharge/-charge.
+        if self.tp_type == 3:
+            pv = float(result.get("pvPower", 0) or 0)
+            grid = float(result.get("gridPower", 0) or 0)
+            batt = float(result.get("batteryExport", 0) or 0) - float(
+                result.get("batteryImport", 0) or 0
+            )
+            load = float(result.get("loadPower", 0) or 0)
+            cur = {"pv": pv, "grid": grid, "batt": batt}
+            active = [k for k, v in cur.items() if abs(v) >= 1]
+            residual = pv + grid + batt - load
+            # Guard: only normalise when we actually have a load reading,
+            # otherwise a missing load would zero out the source flows.
+            if active and load >= 1 and abs(residual) >= 1:
+                d = residual / len(active)
+                for k in active:
+                    nv = cur[k] - d
+                    # Never flip a flow's sign (cap at zero).
+                    if (cur[k] > 0) != (nv > 0) and nv != 0:
+                        nv = 0.0
+                    cur[k] = nv
+                leftover = (cur["pv"] + cur["grid"] + cur["batt"]) - load
+                big = max(active, key=lambda k: abs(cur[k]))
+                cur[big] -= leftover
+
+                result["pvPower"] = max(0, round(cur["pv"]))
+
+                g = round(cur["grid"])
+                result["gridPower"] = g
+                if g > 0:
+                    result["gridImport"], result["gridExport"], result["gridLine"] = g, 0, 1
+                elif g < 0:
+                    result["gridImport"], result["gridExport"], result["gridLine"] = 0, -g, 1
+                else:
+                    result["gridImport"], result["gridExport"], result["gridLine"] = 0, 0, 0
+
+                b = round(cur["batt"])  # +discharge / -charge
+                result["batteryPower"] = abs(b)
+                if b > 0:
+                    result["batteryImport"], result["batteryExport"], result["batteryLine"] = 0, b, 1
+                elif b < 0:
+                    result["batteryImport"], result["batteryExport"], result["batteryLine"] = -b, 0, 2
+                else:
+                    result["batteryImport"], result["batteryExport"], result["batteryLine"] = 0, 0, 0
+                    if result.get("batteryStatus") != 4:
+                        result["batteryStatusText"] = "Standby"
+
         # === BATTERY SOC ===
         # Priority: battTotalSoc (addr 32) > batterySoc (addr 290)
         soc = values.get("battTotalSoc") or values.get("batterySoc") or 0

--- a/custom_components/esy_sunhome/translations/en.json
+++ b/custom_components/esy_sunhome/translations/en.json
@@ -198,6 +198,24 @@
             }
         },
         "number": {
+            "battery_charge_power_pct": {
+                "name": "Battery Charge Power"
+            },
+            "battery_discharge_power_pct": {
+                "name": "Battery Discharge Power"
+            },
+            "export_limit_percent": {
+                "name": "Export Power Limit"
+            },
+            "max_output_power_percent": {
+                "name": "Max Output Power"
+            },
+            "on_grid_soc_limit": {
+                "name": "On-Grid SOC Limit"
+            },
+            "off_grid_soc_limit": {
+                "name": "Off-Grid SOC Limit"
+            },
             "soc_purchase_cutoff": {
                 "name": "SOC Purchase Cutoff"
             },

--- a/tests/test_threephase_decode.py
+++ b/tests/test_threephase_decode.py
@@ -1,0 +1,95 @@
+"""Regression tests for the 3-phase telemetry decode corrections.
+
+These mirror the fixes ported from the solaniq_optimizer ESY adapter:
+  * exclude the single-phase ct1Power CT clamp on 3-phase sites,
+  * treat totalPowerOfGridInFlow as +import (do NOT flip its sign),
+  * prefer the AC-side energyFlowBattPower over the DC batteryPower register,
+  * prefer the inverter energyFlowLoadTotalPower figure for load,
+  * normalise the 3-phase per-source flows to conserve with load
+    (EnergyFlowOptimize), with a guard so a missing load can't zero the flows.
+
+protocol.py is loaded via a synthetic package so its relative imports resolve
+without importing Home Assistant (the real package __init__ pulls in HA).
+"""
+
+import importlib
+import pathlib
+import sys
+import types
+
+_PKG_DIR = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "custom_components" / "esy_sunhome"
+)
+if "esyx" not in sys.modules:
+    _pkg = types.ModuleType("esyx")
+    _pkg.__path__ = [str(_PKG_DIR)]
+    sys.modules["esyx"] = _pkg
+protocol = importlib.import_module("esyx.protocol")
+
+
+def _decode(tp_type, values):
+    parser = protocol.DynamicTelemetryParser(protocol=None)
+    parser.set_tp_type(tp_type)
+    return parser._compute_derived_values(dict(values))
+
+
+def test_single_phase_grid_sign_unchanged():
+    # ESY raw ct1Power negative = import; HA convention flips to +import.
+    r = _decode(1, {"ct1Power": -150, "loadRealTimePower": 500, "batteryStatus": 0})
+    assert r["gridPower"] == 150
+    assert r["gridImport"] == 150 and r["gridExport"] == 0
+
+    r = _decode(1, {"ct1Power": 200, "batteryStatus": 0})
+    assert r["gridPower"] == -200 and r["gridExport"] == 200
+
+
+def test_three_phase_inflow_is_import_and_ct1_excluded():
+    # Balanced frame so the conservation step is a no-op and we isolate
+    # source selection + sign: totalPowerOfGridInFlow is already +import, and
+    # the single-phase ct1Power clamp must be ignored.
+    r = _decode(3, {
+        "totalPowerOfGridInFlow": 800,
+        "ct1Power": -50,
+        "energyFlowLoadTotalPower": 800,
+        "batteryStatus": 0,
+    })
+    assert r["gridPower"] == 800 and r["gridImport"] == 800
+    assert r["loadPower"] == 800
+
+
+def test_battery_prefers_ac_energy_flow_over_dc_register():
+    r = _decode(1, {
+        "energyFlowBattPower": 2200,
+        "batteryPower": 2600,
+        "batteryStatus": 5,  # discharging
+        "loadRealTimePower": 2200,
+    })
+    assert r["batteryPower"] == 2200
+    assert r["batteryExport"] == 2200  # discharge = export from battery
+
+
+def test_three_phase_flows_conserve_with_load():
+    # pv gen 3000, grid export 900, battery charge 2000, measured load 50.
+    r = _decode(3, {
+        "pv1Power": 3000,
+        "totalPowerOfGridInFlow": -900,
+        "energyFlowBattPower": -2000,
+        "batteryStatus": 1,  # charging
+        "energyFlowLoadTotalPower": 50,
+    })
+    signed_batt = r["batteryExport"] - r["batteryImport"]
+    total = r["pvPower"] + r["gridPower"] + signed_batt
+    # Exact up to <=1W independent-rounding of the three flows.
+    assert abs(total - r["loadPower"]) <= 1
+
+
+def test_three_phase_missing_load_does_not_zero_flows():
+    r = _decode(3, {
+        "pv1Power": 3000,
+        "totalPowerOfGridInFlow": -900,
+        "energyFlowBattPower": -2000,
+        "batteryStatus": 1,
+    })
+    assert r["pvPower"] == 3000
+    assert r["gridPower"] == -900


### PR DESCRIPTION
Battery charge/discharge controls now write WATTS to the app's normal-user registers (batteryChargePower / batteryDischargePower) instead of the untested installer current registers, behind a friendly 0-100% slider. The percentage maps to watts against rated AC power (5kW per phase: 5kW single, 15kW 3-phase). Export limit kept as a percentage (grid feed-in cap) and converted to a slider.

Ports the solaniq_optimizer 3-phase telemetry decode fixes into protocol.py, gated on tp_type so single-phase behaviour is unchanged:
  * exclude the single-phase ct1Power CT clamp on 3-phase sites (3a87327)
  * totalPowerOfGridInFlow is +import; no sign flip on 3-phase (7f803f1)
  * prefer inverter flow registers for grid/load (c11ae40) and the AC-side energyFlowBattPower over the DC batteryPower register (ff5fd7d)
  * EnergyFlowOptimize conservation: pv+grid+batt == load, with a guard so a missing load reading can't zero the source flows (5e600f2)
  * 3-phase dataKey aliases; tp_type/phase_count plumbed via the coordinator

Adds standalone regression tests for the 3-phase decode (no HA deps required).