### PR TITLE
fix: pre-import diagnostics module to prevent blocking call warning

### DIFF
--- a/custom_components/esy_sunhome/__init__.py
+++ b/custom_components/esy_sunhome/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from . import diagnostics  # noqa: F401
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -40,9 +41,13 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
-def _import_aiomqtt():
-    """Import aiomqtt in executor thread to avoid blocking warnings."""
+def _preimport_modules():
+    """Import heavy submodules in executor thread to avoid blocking warnings."""
     import aiomqtt  # noqa: F401
+    try:
+        from . import diagnostics  # noqa: F401
+    except Exception:  # pylint: disable=broad-except
+        pass
     return True
 
 
@@ -95,8 +100,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ESY Sunhome from a config entry."""
     _LOGGER.info("Setting up ESY Sunhome integration")
     
-    # Pre-import aiomqtt in executor to avoid blocking call warnings
-    await hass.async_add_executor_job(_import_aiomqtt)
+    # Pre-import modules in executor to avoid blocking call warnings
+    await hass.async_add_executor_job(_preimport_modules)
     
     # Now import our modules (coordinator imports aiomqtt, but it's already cached)
     from .esysunhome import ESYSunhomeAPI

--- a/custom_components/esy_sunhome/diagnostics.py
+++ b/custom_components/esy_sunhome/diagnostics.py
@@ -12,13 +12,14 @@ This provides debug info including:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .coordinator import EsySunhomeCoordinator
+if TYPE_CHECKING:
+    from .coordinator import EsySunhomeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
The integration startup generates a blocking call warning in system logs:

`Detected blocking call to import_module with args ('custom_components.esy_sunhome.diagnostics',) in /usr/src/homeassistant/homeassistant/loader.py inside the event loop`

Updated `diagnostics.py` to wrap the `EsySunhomeCoordinator` type import inside `if TYPE_CHECKING:`. Importing `diagnostics.py` no longer synchronously triggers module loads for `coordinator.py` or `aiomqtt`.

Added `from . import diagnostics` in `__init__.py` to ensure `diagnostics` is cached in `sys.modules` when the integration package loads.

Tested on live HA instance, the blocking call warning is 100% resolved on startup.

Fixes #23